### PR TITLE
Add alias module for macro

### DIFF
--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -16,8 +16,8 @@
 //! }
 
 use callback::Callback;
-use html;
 use html::{ChangeData, Component, ComponentLink, Html, Renderable, ShouldRender};
+use macros::html;
 
 /// `Select` component.
 pub struct Select<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,13 @@ extern crate yew_macro;
 #[macro_use]
 #[cfg(not(feature = "proc_macro"))]
 pub mod macros;
+
+#[cfg(feature = "proc_macro")]
+/// Alias module for the procedural macro.
+pub mod macros {
+    pub use yew_macro::html;
+}
+
 pub mod components;
 pub mod format;
 pub mod services;


### PR DESCRIPTION
Let's keep `macros` module for compatibility.